### PR TITLE
Added ESP32 port based on MCPWM unit

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -12,9 +12,9 @@ Replacement to the standard tone library with many advantages:
 * Can set not only the frequency but also the sound volume
 * Less stress on the speaker so it will last longer and sound better
 
-Disadvantages are that it must use certain pins and it uses two pins instead of one. But, if you're flexible with your pin choices, this is a great upgrade. It also uses timer 1 instead of timer 2, which may free up a conflict you have with the tone library. It exclusively uses port registers for the fastest and smallest code possible (which also makes it **ONLY compatible with ATmega microcontrollers**).
+Disadvantages are that it must use certain pins and it uses two pins instead of one. But, if you're flexible with your pin choices, this is a great upgrade. In case of ATmega microcontrollers, it uses timer 1 instead of timer 2, which may free up a conflict you have with the tone library. It exclusively uses port registers for the fastest and smallest code possible.
 
-== Difference between toneAC and toneAC2 ==
+== Difference between toneAC and toneAC2 (ATmega) ==
 
 First off, toneAC is **SUPERIOR** to [[https://bitbucket.org/teckel12/arduino-toneac2/wiki/Home|toneAC2]]. It's called [[https://bitbucket.org/teckel12/arduino-toneac2/wiki/Home|toneAC2]] only because it uses timer 2, not because it's a newer version of toneAC. [[https://bitbucket.org/teckel12/arduino-toneac2/wiki/Home|toneAC2]] is an alternate but **INFERIOR** version of toneAC that uses timer 2 instead of timer 1 and allows for any two pins to be used. You should use toneAC instead of [[https://bitbucket.org/teckel12/arduino-toneac2/wiki/Home|toneAC2]] if at all possible because toneAC is more accurate, higher quality, allows for higher frequencies, uses fewer CPU cycles, and creates smaller code. However, if you're having a conflict with timer 1, or just can't use the default PWM pins for timer 1, then [[https://bitbucket.org/teckel12/arduino-toneac2/wiki/Home|toneAC2]] may be your answer.
 
@@ -49,19 +49,19 @@ Help future development by making a small donation (the teckel@bex.net payee is 
 
 == Compatibility ==
 
-toneAC is written specifically for the ATmega AVR platform as it uses timer events that only exist with this platform.  Compatibility includes the following platforms/microcontrollers:
+Compatibility includes the following platforms/microcontrollers:
 
-* ATmega328, ATmega128, ATmega640, ATmega8, Uno, Leonardo, ATmega2560/2561, ATmega1280/1281, Mega, ATmega1284P, ATmega644, Teensy 2.0, Teensy++ 2.0
+* ATmega328, ATmega128, ATmega640, ATmega8, Uno, Leonardo, ATmega2560/2561, ATmega1280/1281, Mega, ATmega1284P, ATmega644, Teensy 2.0, Teensy++ 2.0, ESP32
 
 == Connection Example ==
 
-Connection is very similar to a piezo or standard speaker. Except, instead of connecting one speaker wire to ground you connect both speaker wires to Arduino pins. The pins you connect to are specific, as toneAC lets the ATmega microcontroller do all the pin timing and switching. This is important due to the high switching speed possible with toneAC and to make sure the pins are alyways perfectly out of phase with each other (push/pull). See the below list for which pins to use for different Arduinos. Just as usual when connecting a speaker, make sure you add an inline 100 ohm resistor between one of the pins and the speaker wire.
+Connection is very similar to a piezo or standard speaker. Except, instead of connecting one speaker wire to ground you connect both speaker wires to Arduino pins. The pins you connect to are specific, as toneAC lets the microcontroller do all the pin timing and switching. This is important due to the high switching speed possible with toneAC and to make sure the pins are alyways perfectly out of phase with each other (push/pull). See the below list for which pins to use for different Arduinos. Just as usual when connecting a speaker, make sure you add an inline 100 ohm resistor between one of the pins and the speaker wire.
 
 * **Pins 9 & 10** - ATmega328, ATmega128, ATmega640, ATmega8, Uno, Leonardo, etc.
 * **Pins 11 & 12** - ATmega2560/2561, ATmega1280/1281, Mega
 * **Ping 12 & 13** - ATmega1284P, ATmega644
 * **Pins 14 & 15** - Teensy 2.0
-* **Pins 25 & 26** - Teensy++ 2.0
+* **Pins 25 & 26** - Teensy++ 2.0, ESP32
 
 {{https://bitbucket.org/repo/Kg6beL/images/3490992041-toneAC3.png|toneAC3.png}}
 
@@ -117,7 +117,7 @@ void loop() {
 
 The library is named toneAC because it produces an alternating push/pull between two pins. It's not really AC (alternating current) as in-wall electrical wiring because it's a square wave and never produces a negative voltage. However, the effect of the alternating push/pull creates an effective double voltage differential which produces the higher volume level.
 
-The ATmega's PWM takes care of the alternating push/pull so the accuracy is exact. When you send a tone to a speaker with the standard tone library, the loudest is at 50% duty cycle (only on half the time). Which at 5 volts, is like sending only 2.5v to the speaker. With toneAC, we're sending out of phase signals on two pins. So in effect, the speaker is getting 5 volts instead of 2.5, making it nearly twice as loud.
+The ATmega's PWM and ESP32 MCPWM take care of the alternating push/pull so the accuracy is exact. When you send a tone to a speaker with the standard tone library, the loudest is at 50% duty cycle (only on half the time). Which at 5 volts, is like sending only 2.5v to the speaker. With toneAC, we're sending out of phase signals on two pins. So in effect, the speaker is getting 5 volts instead of 2.5, making it nearly twice as loud.
 
 The sound quality difference has to do with allowing the Arduino's PWM to take care of everything and careful programming. Longer piezo life happens because instead of driving the transducer disc only ever in one direction (deforming the disc and reducing sound and quality), it drives it in both directions keeping the disc uniform.
 

--- a/examples/toneAC_demo/toneAC_demo.ino
+++ b/examples/toneAC_demo/toneAC_demo.ino
@@ -4,7 +4,7 @@ Connect a piezo buzzer (without internal oscillator) or speaker to these pins:
   Pins 11 & 12 - ATmega2560/2561, ATmega1280/1281, Mega
   Pins 12 & 13 - ATmega1284P, ATmega644
   Pins 14 & 15 - Teensy 2.0
-  Pins 25 & 26 - Teensy++ 2.0
+  Pins 25 & 26 - Teensy++ 2.0, ESP32
 Be sure to include an inline 100 ohm resistor on one pin as you normally do when connecting a piezo or speaker.
 --------------------------------------------------------------------------- */
 

--- a/examples/toneAC_dual_LED/toneAC_dual_LED.ino
+++ b/examples/toneAC_dual_LED/toneAC_dual_LED.ino
@@ -4,7 +4,7 @@ Connect a two-pin dual LED to the following pins with inline 220 ohm resistor.
   Pins 11 & 12 - ATmega2560/2561, ATmega1280/1281, Mega
   Pins 12 & 13 - ATmega1284P, ATmega644
   Pins 14 & 15 - Teensy 2.0
-  Pins 25 & 26 - Teensy++ 2.0
+  Pins 25 & 26 - Teensy++ 2.0, ESP32
 Connect the center lead of a potentiometer to analog pin A0 and the other two leads to +5V and ground.
 --------------------------------------------------------------------------- */
 

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Replacement to the standard tone library with many advantages
 paragraph=Replacement to the standard tone library with many advantages
 category=Signal Input/Output
 url=https://github.com/teckel12/arduino-toneac
-architectures=avr
+architectures=avr,esp32
 includes=toneAC.h

--- a/src/toneAC.cpp
+++ b/src/toneAC.cpp
@@ -6,11 +6,10 @@ See "toneAC.h" for purpose, syntax, version history, links, and more.
 --------------------------------------------------------------------------- */
 
 #include "toneAC.h"
-
-unsigned long _tAC_time; // Used to track end note with timer when playing note in the background.
-uint8_t _tAC_volume[] = { 200, 100, 67, 50, 40, 33, 29, 22, 11, 2 }; // Duty for linear volume control.
+#include "toneAC_internal.h"
 
 void toneAC(unsigned long frequency, uint8_t volume, unsigned long length, uint8_t background) {
+  toneAC_init();
   if (frequency == NOTONEAC || volume == 0) { noToneAC(); return; } // If frequency or volume are 0, turn off sound and return.
   if (volume > 10) volume = 10;       // Make sure volume is in range (1 to 10).
 
@@ -19,39 +18,9 @@ void toneAC(unsigned long frequency, uint8_t volume, unsigned long length, uint8
   if (length == PLAY_FOREVER) return; // If length is zero, play note forever.
 
   if (background) {                   // Background tone playing, returns control to your sketch.
-    _tAC_time = millis() + length;    // Set when the note should end.
-    TIMSK1 |= _BV(OCIE1A);            // Activate the timer interrupt.
+    noToneAC_setTimer(length);
   } else {
     delay(length);                    // Just a simple delay, doesn't return control till finished.
     noToneAC();
   }
-}
-
-void toneAC_playNote(unsigned long frequency, uint8_t volume) {
-  PWMT1DREG |= _BV(PWMT1AMASK) | _BV(PWMT1BMASK); // Set timer 1 PWM pins to OUTPUT (because analogWrite does it too).
-
-  uint8_t prescaler = _BV(CS10);                  // Try using prescaler 1 first.
-  unsigned long top = F_CPU / frequency / 2 - 1;  // Calculate the top.
-  if (top > 65535) {                              // If not in the range for prescaler 1, use prescaler 256 (122 Hz and lower @ 16 MHz).
-    prescaler = _BV(CS12);                        // Set the 256 prescaler bit.
-    top = top / 256 - 1;                          // Calculate the top using prescaler 256.
-  }
-
-  ICR1   = top;                                     // Set the top.
-  if (TCNT1 > top) TCNT1 = top;                     // Counter over the top, put within range.
-  TCCR1B = _BV(WGM13)  | prescaler;                 // Set PWM, phase and frequency corrected (top=ICR1) and prescaler.
-  OCR1A  = OCR1B = top / _tAC_volume[volume - 1];   // Calculate & set the duty cycle (volume).
-  TCCR1A = _BV(COM1A1) | _BV(COM1B1) | _BV(COM1B0); // Inverted/non-inverted mode (AC).
-}
-
-void noToneAC() {
-  TIMSK1 &= ~_BV(OCIE1A);        // Remove the timer interrupt.
-  TCCR1B  = _BV(CS11);           // Default clock prescaler of 8.
-  TCCR1A  = _BV(WGM10);          // Set to defaults so PWM can work like normal (PWM, phase corrected, 8bit).
-  PWMT1PORT &= ~_BV(PWMT1AMASK); // Set timer 1 PWM pins to LOW.
-  PWMT1PORT &= ~_BV(PWMT1BMASK); // Other timer 1 PWM pin also to LOW.
-}
-
-ISR(TIMER1_COMPA_vect) {                 // Timer interrupt vector.
-  if (millis() >= _tAC_time) noToneAC(); // Check to see if it's time for the note to end.
 }

--- a/src/toneAC.h
+++ b/src/toneAC.h
@@ -27,7 +27,7 @@ USAGE:
 Connection is very similar to a piezo or standard speaker. Except, instead
 of connecting one speaker wire to ground you connect both speaker wires to
 Arduino pins. The pins you connect to are specific, as toneAC lets the
-ATmega microcontroller do all the pin timing and switching. This is
+ATmega/ESP32 microcontroller do all the pin timing and switching. This is
 important due to the high switching speed possible with toneAC and to make
 sure the pins are alyways perfectly out of phase with each other
 (push/pull). See the below CONNECTION section for which pins to use for
@@ -39,7 +39,7 @@ CONNECTION:
   Pins 11 & 12 - ATmega2560/2561, ATmega1280/1281, Mega
   Pins 12 & 13 - ATmega1284P, ATmega644
   Pins 14 & 15 - Teensy 2.0
-  Pins 25 & 26 - Teensy++ 2.0
+  Pins 25 & 26 - Teensy++ 2.0, ESP32
 
 SYNTAX:
   toneAC( frequency [, volume [, length [, background ]]] ) - Play a note.

--- a/src/toneAC.h
+++ b/src/toneAC.h
@@ -90,31 +90,9 @@ to control a two-pin dual LED).
     #include <WProgram.h>
   #endif
 
-  #if defined (__AVR_ATmega32U4__) || defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__)
-    #define PWMT1AMASK DDB5
-    #define PWMT1BMASK DDB6
-    #define PWMT1DREG DDRB
-    #define PWMT1PORT PORTB
-  #elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__)
-    #define PWMT1AMASK DDD4
-    #define PWMT1BMASK DDD5
-    #define PWMT1DREG DDRD
-    #define PWMT1PORT PORTD
-  #else
-    #define PWMT1AMASK DDB1
-    #define PWMT1BMASK DDB2
-    #define PWMT1DREG DDRB
-    #define PWMT1PORT PORTB
-  #endif
-
-  #if defined(__AVR_ATmega8__) || defined(__AVR_ATmega128__)
-    #define TIMSK1 TIMSK
-  #endif
-
   #define NOTONEAC 0
   #define PLAY_FOREVER 0
 
   void toneAC(unsigned long frequency = NOTONEAC, uint8_t volume = 10, unsigned long length = PLAY_FOREVER, uint8_t background = false);
-  void toneAC_playNote(unsigned long frequency, uint8_t volume);
   void noToneAC();
 #endif

--- a/src/toneAC_avr.cpp
+++ b/src/toneAC_avr.cpp
@@ -1,0 +1,72 @@
+/* ---------------------------------------------------------------------------
+Created by Tim Eckel - teckel@leethost.com
+Copyright 2019 License: GNU GPL v3 http://www.gnu.org/licenses/gpl-3.0.html
+
+See "toneAC.h" for purpose, syntax, version history, links, and more.
+--------------------------------------------------------------------------- */
+
+#include "toneAC_internal.h"
+
+#if defined(__AVR__)
+
+#if defined (__AVR_ATmega32U4__) || defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__)
+  #define PWMT1AMASK DDB5
+  #define PWMT1BMASK DDB6
+  #define PWMT1DREG DDRB
+  #define PWMT1PORT PORTB
+#elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__)
+  #define PWMT1AMASK DDD4
+  #define PWMT1BMASK DDD5
+  #define PWMT1DREG DDRD
+  #define PWMT1PORT PORTD
+#else
+  #define PWMT1AMASK DDB1
+  #define PWMT1BMASK DDB2
+  #define PWMT1DREG DDRB
+  #define PWMT1PORT PORTB
+#endif
+
+#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega128__)
+  #define TIMSK1 TIMSK
+#endif
+
+void toneAC_init() {
+}
+
+void toneAC_playNote(unsigned long frequency, uint8_t volume) {
+  PWMT1DREG |= _BV(PWMT1AMASK) | _BV(PWMT1BMASK); // Set timer 1 PWM pins to OUTPUT (because analogWrite does it too).
+
+  uint8_t prescaler = _BV(CS10);                  // Try using prescaler 1 first.
+  unsigned long top = F_CPU / frequency / 2 - 1;  // Calculate the top.
+  if (top > 65535) {                              // If not in the range for prescaler 1, use prescaler 256 (122 Hz and lower @ 16 MHz).
+    prescaler = _BV(CS12);                        // Set the 256 prescaler bit.
+    top = top / 256 - 1;                          // Calculate the top using prescaler 256.
+  }
+
+  ICR1   = top;                                     // Set the top.
+  if (TCNT1 > top) TCNT1 = top;                     // Counter over the top, put within range.
+  TCCR1B = _BV(WGM13)  | prescaler;                 // Set PWM, phase and frequency corrected (top=ICR1) and prescaler.
+  OCR1A  = OCR1B = top / _tAC_volume[volume - 1];   // Calculate & set the duty cycle (volume).
+  TCCR1A = _BV(COM1A1) | _BV(COM1B1) | _BV(COM1B0); // Inverted/non-inverted mode (AC).
+}
+
+void noToneAC() {
+  TIMSK1 &= ~_BV(OCIE1A);        // Remove the timer interrupt.
+  TCCR1B  = _BV(CS11);           // Default clock prescaler of 8.
+  TCCR1A  = _BV(WGM10);          // Set to defaults so PWM can work like normal (PWM, phase corrected, 8bit).
+  PWMT1PORT &= ~_BV(PWMT1AMASK); // Set timer 1 PWM pins to LOW.
+  PWMT1PORT &= ~_BV(PWMT1BMASK); // Other timer 1 PWM pin also to LOW.
+}
+
+unsigned long _tAC_time; // Used to track end note with timer when playing note in the background.
+
+void noToneAC_setTimer(unsigned long delay) {
+  _tAC_time = millis() + delay;     // Set when the note should end.
+  TIMSK1 |= _BV(OCIE1A);            // Activate the timer interrupt.
+}
+
+ISR(TIMER1_COMPA_vect) {                 // Timer interrupt vector.
+  if (millis() >= _tAC_time) noToneAC(); // Check to see if it's time for the note to end.
+}
+
+#endif

--- a/src/toneAC_esp32.cpp
+++ b/src/toneAC_esp32.cpp
@@ -1,0 +1,67 @@
+/* ---------------------------------------------------------------------------
+Created by Tim Eckel - teckel@leethost.com
+Copyright 2019 License: GNU GPL v3 http://www.gnu.org/licenses/gpl-3.0.html
+
+See "toneAC.h" for purpose, syntax, version history, links, and more.
+--------------------------------------------------------------------------- */
+
+#include "toneAC_internal.h"
+
+#if defined(ESP32)
+
+#include <mutex>
+#include <esp32-hal-cpu.h>
+#include <driver/mcpwm.h>
+
+#define MCPWM0APIN 25
+#define MCPWM0BPIN 26
+
+static hw_timer_t *_tAC_timer = NULL;
+static void IRAM_ATTR onTimer();
+
+static std::once_flag _tAC_init;
+
+void toneAC_init() {
+  std::call_once(_tAC_init, [](){
+    // Initialize MCPWM
+    mcpwm_gpio_init(MCPWM_UNIT_0, MCPWM0A, MCPWM0APIN);
+    mcpwm_gpio_init(MCPWM_UNIT_0, MCPWM0B, MCPWM0BPIN);
+    mcpwm_config_t pwm_config;
+    pwm_config.frequency = 1;
+    pwm_config.cmpr_a = 0.0;
+    pwm_config.cmpr_b = 0.0;
+    pwm_config.counter_mode = MCPWM_UP_COUNTER;
+    pwm_config.duty_mode = MCPWM_DUTY_MODE_0;
+    mcpwm_init(MCPWM_UNIT_0, MCPWM_TIMER_0, &pwm_config);
+    mcpwm_deadtime_enable(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_ACTIVE_HIGH_COMPLIMENT_MODE, 0, 0);
+    mcpwm_stop(MCPWM_UNIT_0, MCPWM_TIMER_0);
+    // Initialize timer
+    _tAC_timer = timerBegin(0, ESP.getCpuFreqMHz(), true);
+    timerAttachInterrupt(_tAC_timer, &onTimer, true);
+  });
+}
+
+void toneAC_playNote(unsigned long frequency, uint8_t volume) {
+  float duty = 100.0 / _tAC_volume[volume - 1];
+  mcpwm_set_frequency(MCPWM_UNIT_0, MCPWM_TIMER_0, frequency);
+  mcpwm_set_duty(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_A, duty);
+  mcpwm_set_duty(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_B, duty);
+  mcpwm_start(MCPWM_UNIT_0, MCPWM_TIMER_0);
+}
+
+void noToneAC() {
+  timerAlarmDisable(_tAC_timer);
+  mcpwm_stop(MCPWM_UNIT_0, MCPWM_TIMER_0);
+}
+
+void noToneAC_setTimer(unsigned long delay) {
+  timerAlarmWrite(_tAC_timer, delay * 1000, false);
+  timerRestart(_tAC_timer);
+  timerAlarmEnable(_tAC_timer);
+}
+
+static void IRAM_ATTR onTimer() {
+  noToneAC();
+}
+
+#endif

--- a/src/toneAC_internal.h
+++ b/src/toneAC_internal.h
@@ -1,0 +1,22 @@
+/* ---------------------------------------------------------------------------
+Created by Tim Eckel - teckel@leethost.com
+Copyright 2019 License: GNU GPL v3 http://www.gnu.org/licenses/gpl-3.0.html
+
+See "toneAC.h" for purpose, syntax, version history, links, and more.
+--------------------------------------------------------------------------- */
+
+#ifndef toneAC_internal_h
+  #define toneAC_internal_h
+
+  #include "toneAC.h"
+
+  #if !defined(__AVR__)
+    #error Unsupported architecture
+  #endif
+
+  const uint8_t _tAC_volume[] = { 200, 100, 67, 50, 40, 33, 29, 22, 11, 2 }; // Duty for linear volume control.
+
+  void toneAC_init();
+  void toneAC_playNote(unsigned long frequency, uint8_t volume);
+  void noToneAC_setTimer(unsigned long delay);
+#endif

--- a/src/toneAC_internal.h
+++ b/src/toneAC_internal.h
@@ -10,7 +10,7 @@ See "toneAC.h" for purpose, syntax, version history, links, and more.
 
   #include "toneAC.h"
 
-  #if !defined(__AVR__)
+  #if !defined(__AVR__) && !defined(ESP32)
     #error Unsupported architecture
   #endif
 


### PR DESCRIPTION
I'm working on a project that requires relatively loud transducer-based sound output. By taking advantage of the push-pull drive, the situation can be improved. My platform is ESP32-based, I implemented push-pull using the MCPWM unit.

Initially, I added platform-specific code using preprocessor sections, but that made your AVR implementation harder to read. So, I added dedicated compilation units for platform-specific code while sharing the rest. Consequently, the original implementation should still be as readable and as easy to maintain as before. As a side effect, I moved platform-specific definitions and definitions that are not part of the external interface into the platform-specific files and internal header - internals should be kept private.

In case of ESP32, initialization is required. To keep the original interface, initialization happens during the first call of `toneAC` (thread-safe). The MCPWM and timer calls return an error status but the interfaces used only trigger either `ESP_OK` or `ESP_ERR_INVALID_ARG` - the latter depends on the actual arguments, which are constants except for frequency, duty cycle, and `noToneAC` delay. As long as those are within the accepted range, not checking the status and keeping the original `void` return value does not affect the robustness of the implementation.

The sample works as expected and the AVR implementation still compiles. I updated the documentation accordingly.

As for the pins, I chose the defaults (25 and 26) based on the fact that they are accessible via the HAT interface in case of M5Stack M5StickC PLUS. Of course, they could be made configurable without an issue. The same is not true for AVR, I guess.

More and more ESP32-based development boards become available, so this port could be a useful addition to your library.